### PR TITLE
Add a github action for CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@
             EXTENDED_TESTING: 1
             RELEASE_TESTING: 1
           run: auto-build-and-test-dist
-        - uses: actions/upload-artifact@v3
+        - uses: actions/upload-artifact@v4
           with:
             name: build_dir
             path: build_dir
@@ -38,7 +38,7 @@
         image: perldocker/perl-tester:5.34
       steps:
         - uses: actions/checkout@v4 # codecov wants to be inside a Git repository
-        - uses: actions/download-artifact@v3
+        - uses: actions/download-artifact@v4
           with:
             name: build_dir
             path: .
@@ -85,7 +85,7 @@
           with:
             perl-version: ${{ matrix.perl-version }}
             distribution: ${{ matrix.distribution }}
-        - uses: actions/download-artifact@v3
+        - uses: actions/download-artifact@v4
           with:
             name: build_dir
             path: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,100 @@
+---
+  name: CI
+  
+  on:
+    push:
+      branches:
+        - "*"
+    pull_request:
+      branches:
+        - "*"
+      # # schedule:
+      #   cron: "15 6 * * 0"  # Once weekly, on Sundays
+    workflow_dispatch:
+  jobs:
+    build-job:
+      name: Build distribution
+      runs-on: ubuntu-20.04
+      container:
+        image: perldocker/perl-tester:5.34
+      steps:
+        - uses: actions/checkout@v4
+        - name: Run Tests
+          env:
+            AUTHOR_TESTING: 1
+            AUTOMATED_TESTING: 1
+            EXTENDED_TESTING: 1
+            RELEASE_TESTING: 1
+          run: auto-build-and-test-dist
+        - uses: actions/upload-artifact@v3
+          with:
+            name: build_dir
+            path: build_dir
+          if: ${{ github.actor != 'nektos/act' }}
+    coverage-job:
+      needs: build-job
+      runs-on: ubuntu-20.04
+      container:
+        image: perldocker/perl-tester:5.34
+      steps:
+        - uses: actions/checkout@v4 # codecov wants to be inside a Git repository
+        - uses: actions/download-artifact@v3
+          with:
+            name: build_dir
+            path: .
+        - name: Install deps and test
+          run: cpan-install-dist-deps && test-dist
+          env:
+            CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+    test-job:
+      needs: build-job
+      strategy:
+        fail-fast: true
+        matrix:
+          os: [ubuntu-latest, macos-latest, windows-latest]
+          distribution: [default, strawberry]
+          perl-version:
+            # - "5.8"  Tests fail in 5.8
+            - "5.10"
+            - "5.12"
+            - "5.14"
+            - "5.16"
+            - "5.18"
+            - "5.20"
+            - "5.22"
+            - "5.24"
+            - "5.26"
+            - "5.28"
+            - "5.30"
+            - "5.32"
+            - "5.34"
+            - "5.36"
+            - "5.38"
+          exclude:
+            - { os: windows-latest, distribution: default }
+            - { os: macos-latest,   distribution: strawberry }
+            - { os: ubuntu-latest,  distribution: strawberry }
+            - { distribution: strawberry, perl-version: "5.10" }
+            - { distribution: strawberry, perl-version: "5.12" }
+            - { distribution: strawberry, perl-version: "5.34" }
+      runs-on: ${{ matrix.os }}
+      name:  on ${{ matrix.os }} perl ${{ matrix.perl-version }}
+      steps:
+        - name: set up perl
+          uses: shogo82148/actions-setup-perl@v1
+          with:
+            perl-version: ${{ matrix.perl-version }}
+            distribution: ${{ matrix.distribution }}
+        - uses: actions/download-artifact@v3
+          with:
+            name: build_dir
+            path: .
+        - name: install deps using cpm
+          uses: perl-actions/install-with-cpanm@v1
+          with:
+            cpanfile: "cpanfile"
+            args: "--with-suggests --with-recommends --with-test"
+        - run: prove -lr t
+          env:
+            AUTHOR_TESTING: 0
+            RELEASE_TESTING: 0


### PR DESCRIPTION
I was assigned this repo as part of the [Pull Request Club](https://pullrequest.club). I've added a github action for CI and also added a dependabot config file.
Notes:
1. perl 5.8 files, but only because the tests fail with "no plan", so I've commented it it out of the list of perls to check.
2. The dependabot checks only check for changes in the actions. 
3. You need to enable the dependabot checks in your repo. In the repo go to Settings/Code Security and analysis,